### PR TITLE
pop_topoplot: fix ERP map channel alignment when channels lack locations

### DIFF
--- a/functions/popfunc/pop_topoplot.m
+++ b/functions/popfunc/pop_topoplot.m
@@ -255,7 +255,8 @@ if typeplot
     if isempty(nonEmptyChans)
         nonEmptyChans = 1:EEG.nbchan;
     end
-    SIGTMPAVG = mean(SIGTMP(nonEmptyChans,pos,:),3);
+    SIGTMPAVG = nan(EEG.nbchan, length(pos));
+    SIGTMPAVG(nonEmptyChans,:) = mean(SIGTMP(nonEmptyChans,pos,:),3);
     SIGTMPAVG(nonEmptyChans, nanpos) = NaN;
 
     if isempty(maplimits)


### PR DESCRIPTION
`pop_topoplot` passed only located-channel values alongside the full `chanlocs`, so datasets with interspersed no-location channels (e.g. EOG) plotted ERP data on the wrong electrodes. This builds `SIGTMPAVG` as a full `nbchan`-row array so each channel's value maps to its correct location.