### PR TITLE
Fix pop_selectevent empty epoch guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,15 @@ jobs:
             assert(EEG.nbchan == size(EEG.data, 1));
             assert(EEG.pnts == size(EEG.data, 2));
 
+      - name: Run MATLAB regression tests
+        if: steps.matlab.outputs.available == 'true'
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            cd(getenv('GITHUB_WORKSPACE'));
+            results = runtests('tests');
+            assertSuccess(results);
+
       - name: Skip MATLAB smoke
         if: steps.matlab.outputs.available != 'true'
         run: |

--- a/functions/popfunc/pop_selectevent.m
+++ b/functions/popfunc/pop_selectevent.m
@@ -526,7 +526,7 @@ if strcmp( lower(g.deleteepochs), 'on') && EEG.trials > 1
         Iepoch = ~Iepoch;
     end
 	Iepoch = find(Iepoch == 0);
-    if strcmpi(g.erroronempty, 'on')
+    if isempty(Iepoch) && strcmpi(g.erroronempty, 'on')
         error('All epochs have been removed, empty dataset')
     end
 	if nargin < 2 
@@ -596,4 +596,3 @@ catch
   tmpvarvalue = cell2mat(tmpvarvalue);
 end
 % ======== JRI BUGFIX 3/6/14
-

--- a/tests/test_pop_selectevent.m
+++ b/tests/test_pop_selectevent.m
@@ -1,0 +1,83 @@
+function tests = test_pop_selectevent
+tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+root = fileparts(fileparts(mfilename('fullpath')));
+testCase.applyFixture(matlab.unittest.fixtures.PathFixture(root));
+testCase.applyFixture(matlab.unittest.fixtures.PathFixture(fullfile(root, 'functions'), 'IncludingSubfolders', true));
+end
+
+function testRetainsMatchingEpochs(testCase)
+EEG = fixture;
+selected = pop_selectevent(EEG, 'type', 'target', 'deleteepochs', 'on');
+verifyEqual(testCase, selected.trials, 2);
+verifyEqual(testCase, selected.data, EEG.data(:, :, [1 3]));
+verifyEqual(testCase, numel(selected.event), 4);
+verifyEqual(testCase, [selected.event.epoch], [1 1 2 2]);
+end
+
+function testEmptySelectionErrorsByDefault(testCase)
+verifyError(testCase, @() pop_selectevent(fixture, 'type', 'absent', 'deleteepochs', 'on'), '');
+end
+
+function testEmptySelectionAllowed(testCase)
+selected = pop_selectevent(fixture, 'type', 'absent', 'deleteepochs', 'on', 'erroronempty', 'off');
+verifyEmpty(testCase, selected.data);
+verifyEmpty(testCase, selected.event);
+end
+
+function testInverseEpochSelection(testCase)
+EEG = fixture;
+selected = pop_selectevent(EEG, 'type', 'target', 'deleteepochs', 'on', 'invertepochs', 'on');
+verifyEqual(testCase, selected.data, EEG.data(:, :, [2 4]));
+verifyEqual(testCase, selected.trials, 2);
+end
+
+function testDeleteUnselectedEvents(testCase)
+selected = pop_selectevent(fixture, 'type', 'target', 'deleteepochs', 'on', 'deleteevents', 'on');
+verifyEqual(testCase, {selected.event.type}, {'target' 'target'});
+verifyEqual(testCase, [selected.event.epoch], [1 2]);
+end
+
+function testKeepEpochsWhenDeletingOnlyEvents(testCase)
+EEG = fixture;
+selected = pop_selectevent(EEG, 'type', 'target', 'deleteepochs', 'off', 'deleteevents', 'on');
+verifyEqual(testCase, selected.data, EEG.data);
+verifyEqual(testCase, numel(selected.event), 2);
+end
+
+function testExplicitErrorOptionWithNonemptySelection(testCase)
+EEG = fixture;
+selected = pop_selectevent(EEG, 'type', 'target', 'deleteepochs', 'on', 'erroronempty', 'on');
+verifyEqual(testCase, selected.data, EEG.data(:, :, [1 3]));
+end
+
+function testDatasetArray(testCase)
+EEG = fixture;
+selected = pop_selectevent([EEG EEG], 'type', 'target', 'deleteepochs', 'on');
+verifyEqual(testCase, numel(selected), 2);
+verifyEqual(testCase, [selected.trials], [2 2]);
+verifyEqual(testCase, selected(1).data, EEG.data(:, :, [1 3]));
+verifyEqual(testCase, selected(2).data, EEG.data(:, :, [1 3]));
+end
+
+function EEG = fixture
+EEG = eeg_emptyset;
+EEG.setname = 'selection regression';
+EEG.nbchan = 1;
+EEG.srate = 1000;
+EEG.pnts = 10;
+EEG.trials = 4;
+EEG.xmin = 0;
+EEG.xmax = 0.009;
+EEG.data = reshape(single(1:40), 1, 10, 4);
+EEG.event = struct('type', {}, 'latency', {}, 'epoch', {});
+for trial = 1:4
+  type = 'other';
+  if mod(trial, 2), type = 'target'; end
+  EEG.event(2*trial-1) = struct('type', type, 'latency', (trial-1)*10+3, 'epoch', trial);
+  EEG.event(2*trial) = struct('type', 'distractor', 'latency', (trial-1)*10+7, 'epoch', trial);
+end
+EEG = eeg_checkset(EEG, 'eventconsistency');
+end


### PR DESCRIPTION
## Summary

Restore the missing `isempty(Iepoch)` condition in the epoched event selection guard. `erroronempty='on'` should reject an empty selection, not every selection that deletes epochs.

Add eight deterministic regressions covering selected sample values, epoch and event consistency, empty selections with errors enabled and disabled, inverted epoch selection, event deletion, explicit options, and dataset arrays.

## Verification

MATLAB R2025b on Apple silicon, starting from `sccn/eeglab:develop` at `5c27fc095bc43216ffccdb027f7c40477edf3e2f`.

The regression suite produced 4 passes and 4 failures before the implementation change, then 8 passes and no failures afterward.

All three previously failing EEGLAB test callers pass with the fix: `test_demo_selectevent_glitch`, `test_test_pop_selectevent`, and `test_test_pop_comperp`. The first also exercises overlapping epochs.

Run the new tests from the repository root:

```matlab
results = runtests('tests/test_pop_selectevent.m');
assertSuccess(results);
```

This is problem 2 of the requested local test repair. No plugin changes, statistical algorithm changes, or data files are included.

The new regressions are wired into the existing MATLAB CI job when its license token is available. Octave smoke testing passed. In the current run, the MATLAB execution steps were skipped because the token was unavailable, so the local MATLAB results above are the execution evidence.

Companion PRs: https://github.com/sccn/eeglab_tests/pull/13, https://github.com/sccn/eeglab/pull/956 and https://github.com/LIMO-EEG-Toolbox/limo_tools/pull/239.
