### PR TITLE
Keep the retain flag in pop_subcomp history

### DIFF
--- a/functions/popfunc/pop_subcomp.m
+++ b/functions/popfunc/pop_subcomp.m
@@ -229,7 +229,7 @@ try
     EEG.dipfit.model = EEG.dipfit.model(goodinds);
 catch, end
 
-com = sprintf('EEG = pop_subcomp( EEG, [%s], %d);', int2str(componentsOri(:)'), plotag);
+com = sprintf('EEG = pop_subcomp( EEG, [%s], %d, %d);', int2str(componentsOri(:)'), plotag, keepflag);
 if isempty( components )
     com = [ com ' % [] means removing components flagged for rejection' ];
 end


### PR DESCRIPTION
The GUI path that retains components sets keepflag, but the history string omitted it, so replaying the recorded command removed the retained components instead of keeping them. Verified on the sample ICA dataset that the recorded command now replays to the same data. Fixes #946