### PR TITLE
Create the plugins folder before installing an extension

### DIFF
--- a/functions/adminfunc/plugin_install.m
+++ b/functions/adminfunc/plugin_install.m
@@ -56,6 +56,9 @@ function result = plugin_install(zipfilelink, name, version, pluginsize, forceIn
     %version(find(version == '.'))  = '_';
     generalPluginPath = fullfile(fileparts(which('eeglab.m')), 'plugins');
     newPluginPath     = fullfile(generalPluginPath, [ name version ]);
+    if ~exist(generalPluginPath, 'dir') % fresh installs may not ship the plugins folder
+        mkdir(generalPluginPath);
+    end
 
     % check plugin size
     % -----------------


### PR DESCRIPTION
plugin_install downloaded the extension archive into the plugins folder without creating it, so fresh installs lacking that folder failed with a generic download error. The folder is now created when missing. Syntax checked; the download itself was not exercised offline. Fixes #949