### PR TITLE
Read binary data as single when single precision is enabled

### DIFF
--- a/functions/adminfunc/eeg_getdatact.m
+++ b/functions/adminfunc/eeg_getdatact.m
@@ -238,6 +238,9 @@ else
         % reading data file
         % -----------------
         eeglab_options;
+        % read directly in single precision when requested; reading as double first
+        % needs twice the memory and is much slower for large files
+        if option_single, precision = 'float32=>single'; else, precision = 'float32'; end
         if length(opt.channel) == EEG.nbchan && option_memmapdata
             fclose(fid);
             data = mmo(filename, [EEG.nbchan EEG.pnts EEG.trials], false);
@@ -245,17 +248,17 @@ else
         else
             if datformat
                 if length(opt.channel) == EEG.nbchan || ~isempty(opt.interp)
-                    data = fread(fid, [EEG.trials*EEG.pnts EEG.nbchan], 'float32')';
+                    data = fread(fid, [EEG.trials*EEG.pnts EEG.nbchan], precision)';
                 else
                     data = repmat(single(0), [ length(opt.channel) EEG.pnts EEG.trials ]);
                     for ind = 1:length(opt.channel)
                         fseek(fid, (opt.channel(ind)-1)*EEG.pnts*EEG.trials*4, -1);
-                        data(ind,:) = fread(fid, [EEG.trials*EEG.pnts 1], 'float32')';
+                        data(ind,:) = fread(fid, [EEG.trials*EEG.pnts 1], precision)';
                     end
                     opt.channel = [1:size(data,1)];
                 end
             else
-                data = fread(fid, [EEG.nbchan Inf], 'float32');
+                data = fread(fid, [EEG.nbchan Inf], precision);
             end
             fclose(fid);
         end


### PR DESCRIPTION
eeg_getdatact read float32 data files into double and converted to single afterwards, which doubles the memory needed and makes loading large files very slow. The data is now read directly as single when the single-precision option is on; the double path is unchanged. Verified on the sample dataset that both paths return values identical to a reference read. Fixes #953